### PR TITLE
Feature: autofill username, GUI tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ Webapp/fvserver/fvserver/settings.py
 Webapp/fvserver/fvserver.db
 Build/Crypt.app
 Crypt.xcodeproj/project.xcworkspace/xcuserdata/grahamgilbert.xcuserdatad/UserInterfaceState.xcuserstate
+
+*.xcuserstate
+
+Crypt.xcodeproj/xcuserdata/abanks.xcuserdatad/xcschemes/Crypt.xcscheme
+
+Crypt.xcodeproj/xcuserdata/abanks.xcuserdatad/xcschemes/xcschememanagement.plist

--- a/Crypt.xcodeproj/project.pbxproj
+++ b/Crypt.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2227340F1AA3AC9000C60B2D /* Python in Frameworks */ = {isa = PBXBuildFile; fileRef = 2227340E1AA3AC9000C60B2D /* Python */; };
 		FC4736BF16764FD1003D6F99 /* Crypt.iconset in Resources */ = {isa = PBXBuildFile; fileRef = FC4736BE16764FD1003D6F99 /* Crypt.iconset */; };
 		FC4736C1167650D1003D6F99 /* Crypt.icns in Resources */ = {isa = PBXBuildFile; fileRef = FC4736C0167650D1003D6F99 /* Crypt.icns */; };
 		FC54DB6A1646E4FE00737F94 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC54DB691646E4FE00737F94 /* Cocoa.framework */; };
@@ -19,11 +20,11 @@
 		FCB1D280166C9F7800F05315 /* FVController.py in Resources */ = {isa = PBXBuildFile; fileRef = FCB1D27F166C9F7800F05315 /* FVController.py */; };
 		FCB1D283166CA4FD00F05315 /* FoundationPlist.py in Resources */ = {isa = PBXBuildFile; fileRef = FCB1D282166CA4FD00F05315 /* FoundationPlist.py */; };
 		FCBBD165166CF3EF009BFC08 /* FVUtils.py in Resources */ = {isa = PBXBuildFile; fileRef = FCBBD164166CF3EF009BFC08 /* FVUtils.py */; };
-		FCD750BB182CE5F800478A62 /* Python.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FCD750BA182CE5F800478A62 /* Python.framework */; };
 		FCDFCE89166CB9570077AF7E /* Padlock-icon.png in Resources */ = {isa = PBXBuildFile; fileRef = FCDFCE88166CB9570077AF7E /* Padlock-icon.png */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2227340E1AA3AC9000C60B2D /* Python */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = Python; path = ../../../../../System/Library/Frameworks/Python.framework/Versions/2.7/Python; sourceTree = "<group>"; };
 		FC4736BE16764FD1003D6F99 /* Crypt.iconset */ = {isa = PBXFileReference; lastKnownFileType = folder.iconset; name = Crypt.iconset; path = Crypt/Crypt.iconset; sourceTree = "<group>"; };
 		FC4736C0167650D1003D6F99 /* Crypt.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = Crypt.icns; path = Crypt/Crypt.icns; sourceTree = "<group>"; };
 		FC54DB651646E4FE00737F94 /* Crypt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Crypt.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -42,7 +43,6 @@
 		FCB1D27F166C9F7800F05315 /* FVController.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = FVController.py; sourceTree = "<group>"; };
 		FCB1D282166CA4FD00F05315 /* FoundationPlist.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = FoundationPlist.py; sourceTree = "<group>"; };
 		FCBBD164166CF3EF009BFC08 /* FVUtils.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = FVUtils.py; sourceTree = "<group>"; };
-		FCD750BA182CE5F800478A62 /* Python.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Python.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/System/Library/Frameworks/Python.framework; sourceTree = DEVELOPER_DIR; };
 		FCDFCE88166CB9570077AF7E /* Padlock-icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Padlock-icon.png"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -51,7 +51,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FCD750BB182CE5F800478A62 /* Python.framework in Frameworks */,
+				2227340F1AA3AC9000C60B2D /* Python in Frameworks */,
 				FC54DB6A1646E4FE00737F94 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -81,7 +81,7 @@
 		FC54DB681646E4FE00737F94 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				FCD750BA182CE5F800478A62 /* Python.framework */,
+				2227340E1AA3AC9000C60B2D /* Python */,
 				FC54DB691646E4FE00737F94 /* Cocoa.framework */,
 				FC54DB6D1646E4FE00737F94 /* Other Frameworks */,
 			);
@@ -152,7 +152,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = FV;
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Graham Gilbert";
 			};
 			buildConfigurationList = FC54DB5F1646E4FE00737F94 /* Build configuration list for PBXProject "Crypt" */;
@@ -257,11 +257,11 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					/System/Library/Frameworks/Python.framework/,
+					/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx10.8;
+				SDKROOT = macosx10.9;
 			};
 			name = Debug;
 		};
@@ -284,10 +284,10 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					/System/Library/Frameworks/Python.framework/,
+					/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				SDKROOT = macosx10.8;
+				SDKROOT = macosx10.9;
 			};
 			name = Release;
 		};
@@ -301,13 +301,20 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Crypt/Crypt-Prefix.pch";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7,
+				);
 				INFOPLIST_FILE = "Crypt/Crypt-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SYSTEM_LIBRARY_DIR)/Frameworks/Python.framework/Versions/2.7/lib/python2.7/config",
+					"$(SYSTEM_LIBRARY_DIR)/Frameworks/Python.framework/Versions/2.7",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx10.9;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -322,13 +329,20 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Crypt/Crypt-Prefix.pch";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7,
+				);
 				INFOPLIST_FILE = "Crypt/Crypt-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SYSTEM_LIBRARY_DIR)/Frameworks/Python.framework/Versions/2.7/lib/python2.7/config",
+					"$(SYSTEM_LIBRARY_DIR)/Frameworks/Python.framework/Versions/2.7",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx10.9;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Crypt/FVController.py
+++ b/Crypt/FVController.py
@@ -23,6 +23,7 @@
 import objc
 import FoundationPlist
 import os
+from SystemConfiguration import *
 from Foundation import *
 from AppKit import *
 from Cocoa import *
@@ -143,8 +144,12 @@ class FVController(NSObject):
                                                                                                                   NSLocalizedString(u"There was a problem with enabling encryption on your Mac. Please make sure you are using your short username and that your password is correct. Please contact IT Support if you need help.", None))
         alert.beginSheetModalForWindow_modalDelegate_didEndSelector_contextInfo_(
                                                                                      self.window, self, enable_inputs(self), objc.nil)
-        
-    
+
+    def awakeFromNib(self):
+        cur_console = SCDynamicStoreCopyConsoleUser(None, None, None)[0]
+        if cur_console != "":
+            self.userName.setStringValue_(cur_console)
+
     @objc.IBAction
     def encrypt_(self,sender):
         fvprefspath = "/Library/Preferences/FVServer.plist"
@@ -163,13 +168,11 @@ class FVController(NSObject):
         self.encryptButton.setEnabled_(False)
         
         def enable_inputs(self):
-            self.userName.setEnabled_(True)
             self.password.setEnabled_(True)
             self.encryptButton.setEnabled_(True)
     
         if username_value == "" or password_value == "":
             self.errorField.setStringValue_("You need to enter your username and password")
-            self.userName.setEnabled_(True)
             self.password.setEnabled_(True)
             self.encryptButton.setEnabled_(True)
 

--- a/Crypt/en.lproj/MainMenu.xib
+++ b/Crypt/en.lproj/MainMenu.xib
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4511" systemVersion="13A603" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14D87h" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <deployment defaultVersion="1080" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="4511"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application">
+        <customObject id="-3" userLabel="Application" customClass="NSObject">
             <connections>
                 <outlet property="delegate" destination="373" id="374"/>
             </connections>
@@ -544,40 +544,16 @@
                     <textField focusRingType="none" verticalHuggingPriority="750" id="453">
                         <rect key="frame" x="319" y="239" width="190" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" focusRingType="none" drawsBackground="YES" id="454">
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" focusRingType="none" drawsBackground="YES" id="454">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <secureTextField focusRingType="none" verticalHuggingPriority="750" id="455">
-                        <rect key="frame" x="319" y="212" width="190" height="22"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" focusRingType="none" drawsBackground="YES" usesSingleLineMode="YES" id="456">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            <allowedInputSourceLocales>
-                                <string>NSAllRomanInputSourcesLocaleIdentifier</string>
-                            </allowedInputSourceLocales>
-                        </secureTextFieldCell>
-                        <connections>
-                            <action selector="performClick:" target="486" id="494"/>
-                        </connections>
-                    </secureTextField>
                     <textField verticalHuggingPriority="750" id="459">
                         <rect key="frame" x="92" y="323" width="354" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Your organization requires that your Mac is encrypted." id="460">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <textField verticalHuggingPriority="750" id="461">
-                        <rect key="frame" x="92" y="298" width="351" height="17"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Please enter your username and password to continue." id="462">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -608,6 +584,27 @@
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
+                    <secureTextField verticalHuggingPriority="750" id="NrN-yu-rN4">
+                        <rect key="frame" x="319" y="214" width="190" height="22"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" drawsBackground="YES" usesSingleLineMode="YES" id="fM3-w2-M1g">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            <allowedInputSourceLocales>
+                                <string>NSAllRomanInputSourcesLocaleIdentifier</string>
+                            </allowedInputSourceLocales>
+                        </secureTextFieldCell>
+                    </secureTextField>
+                    <textField verticalHuggingPriority="750" id="461">
+                        <rect key="frame" x="137" y="298" width="264" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Please enter your password to continue." id="462">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
                 </subviews>
             </view>
             <connections>
@@ -620,11 +617,11 @@
             <connections>
                 <outlet property="encryptButton" destination="486" id="498"/>
                 <outlet property="errorField" destination="496" id="497"/>
-                <outlet property="password" destination="456" id="472"/>
+                <outlet property="password" destination="NrN-yu-rN4" id="Jfa-Nm-cxh"/>
                 <outlet property="progressIndicator" destination="nrD-GE-D8u" id="Sx2-Ol-rz6"/>
                 <outlet property="progressPanel" destination="aRA-rz-VqL" id="6yT-um-Wph"/>
                 <outlet property="progressText" destination="2nJ-0o-evk" id="s8a-Gr-VLL"/>
-                <outlet property="userName" destination="454" id="471"/>
+                <outlet property="userName" destination="453" id="jgy-EE-22C"/>
                 <outlet property="window" destination="371" id="ope-8C-n1d"/>
             </connections>
         </customObject>

--- a/Crypt/main.m
+++ b/Crypt/main.m
@@ -21,7 +21,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-#import <Python/Python.h>
+#import <Python.h>
 int main(int argc, char *argv[])
 {
 


### PR DESCRIPTION
This is cumulative, based on the previous xcode-6-updates branch, so you may want to eval/merge that first, and optionally merge this to a topic branch outside of master for now.

Added an import to use the SCDynamicStoreCopyConsoleUser method of grabbing the current user, which therefore only leaves the password field for end users to fill in. 
Also added an awakeFromNib(self) function to run the console user check and populate the field, could use some more testing. 
Since we wouldn't get here without a successful auth I thought it wouldn't be useful to allow changing their mind about what user to escrow with, so I disabled username field.
Updated wording as a result, did a tweak to hopefully fix an issue with the cursor not appearing in the password field when activated.
![screen shot 2015-03-01 at 5 09 41 pm](https://cloud.githubusercontent.com/assets/388808/6433177/d39ddd48-c035-11e4-9fa2-f003ffc9be22.png)