### PR TITLE
Abort if Apple Recovery Partition does not exist for some reason

### DIFF
--- a/Example Login Hook/filevault.sh
+++ b/Example Login Hook/filevault.sh
@@ -33,6 +33,11 @@ check_encryption_state() {
     log "Disk encrypting or decrypting, skipping."
     exit 0
   fi
+  ${DISKUTIL} list | grep -c Apple_Boot
+  if [[ ${?} -eq 0 ]]; then
+    log "Apple Recovery Partition does not exist, skipping."
+    exit 0
+  fi
 }
 
 

--- a/Example script for LoginScriptPlugin/postmount-root-filevault.sh
+++ b/Example script for LoginScriptPlugin/postmount-root-filevault.sh
@@ -33,6 +33,11 @@ check_encryption_state() {
     log "Disk encrypting or decrypting, skipping."
     exit 0
   fi
+  ${DISKUTIL} list | grep -c Apple_Boot
+  if [[ ${?} -eq 0 ]]; then
+    log "Apple Recovery Partition does not exist, skipping."
+    exit 0
+  fi
 }
 
 


### PR DESCRIPTION
This resolves issue #26 with Crypt hanging if the apple recovery partition doesn't exist