### PR TITLE
fix remove_plist logic

### DIFF
--- a/Package/checkin
+++ b/Package/checkin
@@ -228,7 +228,7 @@ def main():
             plist['last_run'] = datetime.datetime.now()
             logging.info('Successfully escrowed key.')
             FoundationPlist.writePlist(plist, PLIST_PATH)
-            if remove_plist:
+            if remove_plist == True:
                 os.remove(PLIST_PATH)
                 logging.info('Removing plist due to configuration.')
 


### PR DESCRIPTION
The current logic was only looking to see if `RemovePlist` was present, not on it's actual value.

This lead to the plist being removed, even if a `False` value was specified.
