### PR TITLE
Swift 2.3/Xcode 8

### DIFF
--- a/Crypt.xcodeproj/project.pbxproj
+++ b/Crypt.xcodeproj/project.pbxproj
@@ -186,10 +186,12 @@
 				TargetAttributes = {
 					C7AD38F21D22B049000FB736 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					FCD4FD931BEE763C00CF7F48 = {
 						CreatedOnToolsVersion = 7.1;
 						DevelopmentTeam = 9D8XP85393;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -272,6 +274,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.grahamgilbert.FDEAddUserService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -283,6 +286,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.grahamgilbert.FDEAddUserService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -380,6 +384,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Crypt/Crypt-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Debug;
@@ -398,6 +403,7 @@
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Crypt/Crypt-Bridging-Header.h";
+				SWIFT_VERSION = 2.3;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Release;


### PR DESCRIPTION
Migrates to Swift 2.3. There were no code changes needed, but I did receive a warning that future versions of Xcode will require moving to Swift 3.0

This fixed build errors with Xcode 8 on Sierra.
