### PR TITLE
only import specific modules used from foundation

### DIFF
--- a/Package/checkin
+++ b/Package/checkin
@@ -7,9 +7,13 @@ import urllib
 import sys
 import datetime
 import syslog
-
-from Foundation import *
 import FoundationPlist
+from Foundation import NSDate
+from Foundation import CFPreferencesAppSynchronize
+from Foundation import CFPreferencesCopyAppValue
+from Foundation import CFPreferencesSetValue
+from Foundation import kCFPreferencesAnyUser
+from Foundation import kCFPreferencesCurrentHost
 
 BUNDLE_ID = 'com.grahamgilbert.crypt'
 PLIST_PATH = '/private/var/root/crypt_output.plist'


### PR DESCRIPTION
this drops the runtime by about 75%. 