### PR TITLE
Remove the plist if we cannot validate the key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ Carthage/Build
 Crypt/Crypt.xcodeproj/project.xcworkspace/contents.xcworkspacedata
 
 *.pkg
+*.pyc

--- a/Package/checkin
+++ b/Package/checkin
@@ -7,7 +7,11 @@ import urllib
 import sys
 import datetime
 import syslog
+import platform
+from distutils.version import LooseVersion
+
 import FoundationPlist
+
 from Foundation import NSDate
 from Foundation import CFPreferencesAppSynchronize
 from Foundation import CFPreferencesCopyAppValue
@@ -33,6 +37,21 @@ def get_console_user():
     cfuser = SCDynamicStoreCopyConsoleUser(None, None, None)
     return cfuser[0]
 
+def get_os_version(only_major_minor=True, as_tuple=False):
+    """Returns an OS version.
+    Args:
+      only_major_minor: Boolean. If True, only include major/minor versions.
+      as_tuple: Boolean. If True, return a tuple of ints, otherwise a string.
+    100%, completely stolen from Munki.
+    """
+    os_version_tuple = platform.mac_ver()[0].split('.')
+    if only_major_minor:
+        os_version_tuple = os_version_tuple[0:2]
+    if as_tuple:
+        return tuple(map(int, os_version_tuple))
+    else:
+        return '.'.join(os_version_tuple)
+
 def set_pref(pref_name, pref_value):
     """Sets a preference, writing it to
         /Library/Preferences/com.grahamgilbert.crypt.plist.
@@ -41,8 +60,8 @@ def set_pref(pref_name, pref_value):
         elsewhere (by MCX, for example)"""
     try:
         CFPreferencesSetValue(
-                      pref_name, pref_value, BUNDLE_ID,
-                      kCFPreferencesAnyUser, kCFPreferencesCurrentHost)
+            pref_name, pref_value, BUNDLE_ID,
+            kCFPreferencesAnyUser, kCFPreferencesCurrentHost)
         CFPreferencesAppSynchronize(BUNDLE_ID)
     except Exception:
         pass
@@ -59,7 +78,8 @@ def pref(pref_name):
     default_prefs = {
         'RemovePlist': True,
         'RotateUsedKey': True,
-        'OutputPath': '/private/var/root/crypt_output.plist'
+        'OutputPath': '/private/var/root/crypt_output.plist',
+        'ValidateKey': True
     }
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     if pref_value is None:
@@ -75,6 +95,9 @@ def pref(pref_name):
 
 
 def GetMacName():
+    """
+    Returns the name of the mac
+    """
     theprocess = ['scutil', '--get', 'ComputerName']
     thename = subprocess.Popen(theprocess, stdin=subprocess.PIPE,
                                stdout=subprocess.PIPE).communicate()[0]
@@ -116,10 +139,14 @@ def using_recovery_key():
     the recovery key.
     """
     cmd = ['/usr/bin/fdesetup', 'usingrecoverykey']
-    using_key = subprocess.check_output(cmd).strip()
+    try:
+        using_key = subprocess.check_output(cmd).strip()
+    except Exception:
+        logging.warning('fdesetup usingrecoverykey failed to run correctly')
+        return False
     if using_key == 'true':
-        return True
         logging.warning('Detected Recovery Key use.')
+        return True
     else:
         return False
 
@@ -141,6 +168,39 @@ def get_recovery_key(key_location):
             'Problem with Key: RecoveryKey in {0}...'.format(key_location))
         return False
 
+def rotate_invalid_key(plist_path):
+    """
+    Will send the key (if present) for validation. If validation fails,
+    it will remove the plist so the key can be regenerated at next login.
+    Due to the bug that restricts the number of validations before reboot
+    in versions of macOS prior to 10.12.5, this will only run there.
+    """
+
+    macos_version = get_os_version(only_major_minor=False, as_tuple=False)
+
+    if LooseVersion('10.12.5') > LooseVersion(macos_version):
+        logging.warning('macOS version is too old to run reliably')
+        return False
+
+    if os.path.exists(plist_path):
+        recovery_key = get_recovery_key(plist_path)
+    else:
+        logging.warning('Recovery key is not present on disk')
+        return False
+
+    if recovery_key is not False:
+        key_is_valid = validate_key(recovery_key)
+    else:
+        logging.warning('Could not retrieve recovery key from plist')
+        return False
+
+    if not key_is_valid:
+        logging.info('Stored recovery key is not valid, removing from disk')
+        os.remove(plist_path)
+        return False
+
+    logging.info('Stored recovery key is valid.')
+    return True
 
 def validate_key(current_key):
     """Validates the given recovery key against FileVault, returns True
@@ -221,6 +281,11 @@ def main():
     logging.info('OutputPath Pref is set to: {}'.format(plist_path))
     if pref('RotateUsedKey'):
         rotate_if_used(plist_path)
+
+    if pref('RotateUsedKey') and pref('ValidateKey') and \
+    not pref('RemovePlist'):
+        rotate_invalid_key(plist_path)
+
     if os.path.isfile(plist_path):
         plist = FoundationPlist.readPlist(plist_path)
         # Exit if we've run this within the last hour


### PR DESCRIPTION
On 10.12.5 and later, we now have the option to validate the recovery key if it is stored on disk.

This also catches an error when we are testing if the recovery key is being used on an unreleased version of macOS. This kludge is not ideal, but it is better than not running at all.