### PR TITLE
Crypt3

### DIFF
--- a/Crypt/Info.plist
+++ b/Crypt/Info.plist
@@ -15,13 +15,13 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.1</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2.3.1</string>
+	<string>3.0.0</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2016 The Crypt Project. All rights reserved.</string>
+	<string>Copyright © 2017 The Crypt Project. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Package/Distribution-Template
+++ b/Package/Distribution-Template
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="1">
+    <title>Crypt replace_version</title>
+    <pkg-ref id="com.grahamgilbert.Crypt"/>
+    <options rootVolumeOnly="true" />
+    <volume-check>
+    	<allowed-os-versions>
+    	    <os-version min="10.12.0" />
+    	</allowed-os-versions>
+    </volume-check>
+    <options customize="never" require-scripts="false"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="com.grahamgilbert.Crypt"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="com.grahamgilbert.Crypt" visible="false">
+        <pkg-ref id="com.grahamgilbert.Crypt"/>
+    </choice>
+    <pkg-ref id="com.grahamgilbert.Crypt" version="replace_version" onConclusion="RequireRestart">Crypt.pkg</pkg-ref>
+</installer-gui-script>

--- a/Package/Makefile
+++ b/Package/Makefile
@@ -5,6 +5,7 @@ GITVERSION=$(shell ./build_no.sh)
 BUNDLE_VERSION=$(shell /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "../Crypt/Info.plist")
 PACKAGE_VERSION=${BUNDLE_VERSION}.${GITVERSION}
 REVERSE_DOMAIN=com.grahamgilbert
+PACKAGE_NAME=${TITLE}
 PAYLOAD=\
 			pack-plugin\
 			pack-script-postinstall\
@@ -30,3 +31,10 @@ pack-checkin: l_Library
 	@sudo ${CP} FoundationPlist.py ${WORK_D}/Library/Crypt/FoundationPlist.py
 	@sudo chown -R root:wheel ${WORK_D}/Library/Crypt
 	@sudo chmod 755 ${WORK_D}/Library/Crypt/checkin
+
+dist: pkg
+	@sudo rm -f Distribution
+	python generate_dist.py
+	@sudo productbuild --distribution Distribution Crypt-${BUNDLE_VERSION}.pkg
+	@sudo rm -f Crypt.pkg
+	@sudo rm -f Distribution

--- a/Package/generate_dist.py
+++ b/Package/generate_dist.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 """
-Adds the OS check to a generated distribution file
+Sets the right version number and writes the Distribution file from the template
 """
 
 import plistlib

--- a/Package/generate_dist.py
+++ b/Package/generate_dist.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+
+"""
+Adds the OS check to a generated distribution file
+"""
+
+import plistlib
+import os
+
+def main():
+    """
+    FINAL COUNTDOWN
+    """
+    crypt_plist = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'Crypt','Info.plist')
+    version = plistlib.readPlist(crypt_plist)['CFBundleShortVersionString']
+
+    with open('Distribution-Template', 'r') as the_file:
+        filedata = the_file.read()
+
+    # Replace the target string
+    filedata = filedata.replace('replace_version', version)
+
+    # Write the file out again
+    with open('Distribution', 'w') as the_file:
+        the_file.write(filedata)
+
+if __name__ == '__main__':
+    main()

--- a/Package/preinstall
+++ b/Package/preinstall
@@ -3,13 +3,16 @@
 import os
 import shutil
 import sys
+import platform
 
 import syslog
 syslog.openlog("crypt-preinstall")
 
-def fail(message):
+def fail(message, exit=True):
     syslog.syslog(syslog.LOG_ALERT, message)
-    sys.exit(1)
+    print(message)
+    if exit:
+        sys.exit(1)
 
 def move_old_plist():
     old_plist = '/private/var/root/recovery_key.plist'
@@ -28,8 +31,34 @@ def remove_old_app():
         shutil.rmtree(old_install_dir)
 
 
+def getOsVersion(only_major_minor=True, as_tuple=False):
+    """Returns an OS version.
+    Args:
+      only_major_minor: Boolean. If True, only include major/minor versions.
+      as_tuple: Boolean. If True, return a tuple of ints, otherwise a string.
+    """
+    os_version_tuple = platform.mac_ver()[0].split('.')
+    if only_major_minor:
+        os_version_tuple = os_version_tuple[0:2]
+    if as_tuple:
+        return tuple(map(int, os_version_tuple))
+    else:
+        return '.'.join(os_version_tuple)
+
+
+def os_check_abort():
+    # abort if less than 10.12
+    version_tup = getOsVersion(as_tuple=True)
+    if version_tup[1] < 12:
+        fail('ERROR! Crypt 3.0 does not support macOS versions before 10.12..',
+             exit=False)
+        fail('ERROR! Please use a previous version of Crypt..')
+
+
 def main():
+    os_check_abort()
     move_old_plist()
+    print('crypt-preinstall successful...')
 
 if __name__ == '__main__':
     main()

--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@
 
 Crypt 2 is an authorization plugin that will enforce FileVault 2, and then submit it to an instance of [Crypt Server](https://github.com/grahamgilbert/crypt-server). Crypt 2 has been tested against 10.11 and 10.12 - it should in theory work down to 10.9, but test throughly to ensure it works as expected.
 
+Version 3.0.0 now supports 10.12 and above, previous macOS version support has been deprecated!
+
 ## Features
 
 * Uses native authorization plugin so FileVault enforcement cannot be skipped.
 * Escrow is delayed until there is an active user, so FileVault can be enforced when the Mac is offline.
 * Administrators can specify a series of username that should not have to enable FileVault (IT admin, for example).
 
-#### New in v2.3.0
-* Added support for the use of Institutional Keys along with the default Personal Recovery Key. Just add your master keychain file at '/Library/Keychains/FileVaultMaster.keychain' and Crypt2 will handle the rest during initial Enablement.
+#### New in v3.0.0
+* Deprecated Support for before 10.12. Please use version 2.2.0.
+* High Sierra Support.
+* Added support for the use of Institutional Keys along with the default Personal Recovery Key. Just add your master keychain file at '/Library/Keychains/FileVaultMaster.keychain' and Crypt will handle the rest during initial Enablement.
 * If the RotateUsedKey preference is True and RemovePlist is False and the file defined by OutputPath is missing from disk, a new Recovery key will be generated at login.
 * OutputPath Preference. More info below.
 * Local Recovery Key validation on 10.12.5+. More info below.
@@ -39,7 +43,7 @@ $ sudo defaults write /Library/Preferences/com.grahamgilbert.crypt SkipUsers -ar
 
 ### RemovePlist
 
-By default, the plist with the FileVault Key will be removed once it has been escrowed. In a future version of Crypt, there will be the possibility of verifying the escrowed key with the client. In preparation for this feature, you can now choose to leave the key on disk. 
+By default, the plist with the FileVault Key will be removed once it has been escrowed. In a future version of Crypt, there will be the possibility of verifying the escrowed key with the client. In preparation for this feature, you can now choose to leave the key on disk.
 
 ``` bash
 $ sudo defaults write /Library/Preferences/com.grahamgilbert.crypt RemovePlist -bool FALSE
@@ -70,7 +74,7 @@ $ sudo defaults write /Library/Preferences/com.grahamgilbert.crypt FDEAddUser -b
 ```
 ### OutputPath
 
-As of version 2.3.0 you can now define a new location for where the recovery key is written to. Default for this is `'/var/root/crypt_output.plist'`.
+As of version 3.0.0 you can now define a new location for where the recovery key is written to. Default for this is `'/var/root/crypt_output.plist'`.
 
 ``` bash
 $ sudo defaults write /Library/Preferences/com.grahamgilbert.crypt OutputPath "/path/to/different/location"
@@ -78,7 +82,7 @@ $ sudo defaults write /Library/Preferences/com.grahamgilbert.crypt OutputPath "/
 
 ### KeyEscrowInterval
 
-As of version 2.3.0 you can now define the time interval in Hours for how often Crypt tries to re-escrow the key, after the first successful escrow. Default for this is `1` hour.
+As of version 3.0.0 you can now define the time interval in Hours for how often Crypt tries to re-escrow the key, after the first successful escrow. Default for this is `1` hour.
 
 ``` bash
 $ sudo defaults write /Library/Preferences/com.grahamgilbert.crypt KeyEscrowInterval -int 2


### PR DESCRIPTION
Preinstall will now abort if macOS version is less than 10.12
updated readme accordingly.