### PR TITLE
Highsierra refactor

### DIFF
--- a/Crypt.xcodeproj/project.pbxproj
+++ b/Crypt.xcodeproj/project.pbxproj
@@ -201,13 +201,11 @@
 				TargetAttributes = {
 					C7AD38F21D22B049000FB736 = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = 6LJUSYJRZ2;
 						LastSwiftMigration = 0830;
 						ProvisioningStyle = Automatic;
 					};
 					FCD4FD931BEE763C00CF7F48 = {
 						CreatedOnToolsVersion = 7.1;
-						DevelopmentTeam = 6LJUSYJRZ2;
 						LastSwiftMigration = 0830;
 						ProvisioningStyle = Automatic;
 					};
@@ -307,7 +305,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 6LJUSYJRZ2;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = FDEAddUserService/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = com.grahamgilbert.FDEAddUserService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -322,7 +320,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 6LJUSYJRZ2;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = FDEAddUserService/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = com.grahamgilbert.FDEAddUserService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -425,7 +423,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 6LJUSYJRZ2;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Crypt/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -448,7 +446,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 6LJUSYJRZ2;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Crypt/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";

--- a/Crypt.xcodeproj/project.pbxproj
+++ b/Crypt.xcodeproj/project.pbxproj
@@ -201,11 +201,13 @@
 				TargetAttributes = {
 					C7AD38F21D22B049000FB736 = {
 						CreatedOnToolsVersion = 7.2;
+						DevelopmentTeam = 6LJUSYJRZ2;
 						LastSwiftMigration = 0830;
 						ProvisioningStyle = Automatic;
 					};
 					FCD4FD931BEE763C00CF7F48 = {
 						CreatedOnToolsVersion = 7.1;
+						DevelopmentTeam = 6LJUSYJRZ2;
 						LastSwiftMigration = 0830;
 						ProvisioningStyle = Automatic;
 					};
@@ -305,7 +307,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6LJUSYJRZ2;
 				INFOPLIST_FILE = FDEAddUserService/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = com.grahamgilbert.FDEAddUserService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -320,7 +322,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6LJUSYJRZ2;
 				INFOPLIST_FILE = FDEAddUserService/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = com.grahamgilbert.FDEAddUserService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -423,7 +425,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6LJUSYJRZ2;
 				INFOPLIST_FILE = Crypt/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -446,7 +448,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6LJUSYJRZ2;
 				INFOPLIST_FILE = Crypt/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";

--- a/Crypt/Info.plist
+++ b/Crypt/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3.0.0</string>
+	<string>3.0.1</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2017 The Crypt Project. All rights reserved.</string>
 	<key>NSPrincipalClass</key>

--- a/Crypt/Mechanisms/Check.swift
+++ b/Crypt/Mechanisms/Check.swift
@@ -154,7 +154,7 @@ class Check: CryptMechanism {
       _ = allowLogin()
       return;
     }
-    else if onHighSierraOrNewer() {
+    else if onHighSierraOrNewer() && onAPFS() {
       // we're on high sierra we can just enable
       os_log("On High Sierra and not enabled. Starting Enablement...", log: Check.log, type: .default)
       do {

--- a/Crypt/Mechanisms/CryptMechanism.swift
+++ b/Crypt/Mechanisms/CryptMechanism.swift
@@ -230,7 +230,7 @@ class CryptMechanism: NSObject {
     task.arguments = ["enable", "-outputplist", "-inputplist"]
     
     // check if we should do an authrestart on enablement
-    if checkAuthRestart() {
+    if checkAuthRestart() && !onAPFS(){
       os_log("adding -authrestart flag at index 1 of our task arguments...", log: CryptMechanism.log, type: .default)
       task.arguments?.insert("-authrestart", at: 1)
     }
@@ -286,6 +286,24 @@ class CryptMechanism: NSObject {
     } else {
       os_log("rotateRecoveryKey() Error. Format does not equal 'PropertyListSerialization.PropertyListFormat.xml'", log: CryptMechanism.log, type: .error)
       throw FileVaultError.outputPlistMalformed
+    }
+  }
+  
+  func onAPFS() -> Bool {
+    // checks to see if our boot drive is APFS
+    let ws = NSWorkspace.shared
+    
+    var myDes: NSString? = nil
+    var myType: NSString? = nil
+    
+    ws().getFileSystemInfo(forPath: "/", isRemovable: nil, isWritable: nil, isUnmountable: nil, description: &myDes, type: &myType)
+    
+    if myType == "apfs" {
+      os_log("Machine appears to be APFS", log: CryptMechanism.log, type: .default)
+      return true
+    } else {
+      os_log("Machine is not APFS we appear to be: %{public}@", log: CryptMechanism.log, type: .default, String(describing: myType))
+      return false
     }
   }
   

--- a/Crypt/Mechanisms/CryptMechanism.swift
+++ b/Crypt/Mechanisms/CryptMechanism.swift
@@ -138,4 +138,166 @@ class CryptMechanism: NSObject {
     _ = self.mechanism.pointee.fPlugin.pointee.fCallbacks.pointee.SetResult(
       mechanism.pointee.fEngine, AuthorizationResult.allow)
   }
+
+  func needToRestart() -> Bool {
+    os_log("Checking to see if we need to restart now because we may not be on APFS", log: CryptMechanism.log, type: .default)
+    let task = Process();
+    task.launchPath = "/usr/bin/fdesetup"
+    task.arguments = ["status"]
+    let pipe = Pipe()
+    task.standardOutput = pipe
+    task.launch()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let output: String = String(data: data, encoding: String.Encoding.utf8)
+      else { return true }
+    if ((output.range(of: "restart")) != nil) {
+      os_log("Looks like we need to restart...", log: CryptMechanism.log, type: .default)
+      return true
+    } else {
+      os_log("No restart needed.", log: CryptMechanism.log, type: .default)
+      return false
+    }
+  }
+  
+  // check if on 10.13+
+  func onHighSierraOrNewer() -> Bool {
+    os_log("Checking to see if on 10.13+", log: CryptMechanism.log, type: .default)
+    return ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion.init(majorVersion: 10, minorVersion: 13, patchVersion: 0))
+  }
+  
+  // check authrestart capability
+  func checkAuthRestart() -> Bool {
+    let outPipe = Pipe.init()
+    let authRestartCheck = Process.init()
+    authRestartCheck.launchPath = "/usr/bin/fdesetup"
+    authRestartCheck.arguments = ["supportsauthrestart"]
+    authRestartCheck.standardOutput = outPipe
+    authRestartCheck.launch()
+    let outputData = outPipe.fileHandleForReading.availableData
+    let outputString = String(data: outputData, encoding: String.Encoding.utf8) ?? ""
+    if (outputString.range(of: "true") != nil) {
+      os_log("Authrestart capability is 'true', will authrestart as appropriate", log: CryptMechanism.log, type: .default)
+      return true
+    }
+    else {
+      os_log("Authrestart capability is 'false', reverting to standard reboot", log: CryptMechanism.log, type: .default)
+      return false
+    }
+  }
+  
+  // fdesetup Errors
+  private enum FileVaultError: Error {
+    case fdeSetupFailed(retCode: Int32)
+    case outputPlistNull
+    case outputPlistMalformed
+  }
+  
+  // Check if some information on filevault whether it's encrypted and if decrypting.
+  func getFVEnabled() -> (encrypted: Bool, decrypting: Bool) {
+    os_log("Checking the current status of FileVault..", log: CryptMechanism.log, type: .default)
+    let task = Process();
+    task.launchPath = "/usr/bin/fdesetup"
+    task.arguments = ["status"]
+    let pipe = Pipe()
+    task.standardOutput = pipe
+    task.launch()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let output: String = String(data: data, encoding: String.Encoding.utf8)
+      else { return (false, false) }
+    if ((output.range(of: "FileVault is On.")) != nil) {
+      os_log("Filevault is On...", log: CryptMechanism.log, type: .default)
+      return (true, false)
+    } else if (output.range(of: "Decryption in progress:") != nil) {
+      os_log("FileVault Decryption in progress...", log: CryptMechanism.log, type: .error)
+      return (true, true)
+    } else {
+      os_log("FileVault is not enabled...", log: CryptMechanism.log, type: .error)
+      return (false, false)
+    }
+  }
+
+  func enableFileVault(_ theSettings : NSDictionary, filepath : String) throws -> Bool {
+    os_log("Attempting to enable FileVault", log: CryptMechanism.log, type: .default)
+    let inputPlist = try PropertyListSerialization.data(fromPropertyList: theSettings,
+                                                        format: PropertyListSerialization.PropertyListFormat.xml, options: 0)
+    
+    let inPipe = Pipe.init()
+    let outPipe = Pipe.init()
+    let errorPipe = Pipe.init()
+    
+    let task = Process.init()
+    task.launchPath = "/usr/bin/fdesetup"
+    task.arguments = ["enable", "-outputplist", "-inputplist"]
+    
+    // check if we should do an authrestart on enablement
+    if checkAuthRestart() {
+      os_log("adding -authrestart flag at index 1 of our task arguments...", log: CryptMechanism.log, type: .default)
+      task.arguments?.insert("-authrestart", at: 1)
+    }
+    
+    // if there's an IRK, need to add the -keychain argument to keep us from failing.
+    let instKeyPath = "/Library/Keychains/FileVaultMaster.keychain"
+    if checkFileExists(path: instKeyPath) {
+      os_log("Appending -keychain to the end of our task arguments...", log: CryptMechanism.log, type: .default)
+      task.arguments?.append("-keychain")
+    }
+    
+    os_log("Running /usr/bin/fdesetup %{public}@", log: CryptMechanism.log, type: .default, String(describing: task.arguments))
+    
+    task.standardInput = inPipe
+    task.standardOutput = outPipe
+    task.standardError = errorPipe
+    task.launch()
+    inPipe.fileHandleForWriting.write(inputPlist)
+    inPipe.fileHandleForWriting.closeFile()
+    task.waitUntilExit()
+    
+    os_log("Trying to get output data", log: CryptMechanism.log, type: .default)
+    let outputData = outPipe.fileHandleForReading.readDataToEndOfFile()
+    outPipe.fileHandleForReading.closeFile()
+    
+    let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+    let errorMessage = String(data: errorData, encoding: .utf8)
+    errorPipe.fileHandleForReading.closeFile()
+    
+    if task.terminationStatus != 0 {
+      let termstatus = String(describing: task.terminationStatus)
+      os_log("fdesetup terminated with a NON-Zero exit status: %{public}@", log: CryptMechanism.log, type: .error, termstatus)
+      os_log("fdesetup Standard Error: %{public}@", log: CryptMechanism.log, type: .error, String(describing: errorMessage))
+      throw FileVaultError.fdeSetupFailed(retCode: task.terminationStatus)
+    }
+    
+    if outputData.count == 0 {
+      os_log("Found nothing in output data", log: CryptMechanism.log, type: .error)
+      throw FileVaultError.outputPlistNull
+    }
+    
+    var format : PropertyListSerialization.PropertyListFormat = PropertyListSerialization.PropertyListFormat.xml
+    let outputPlist = try PropertyListSerialization.propertyList(from: outputData,
+                                                                 options: PropertyListSerialization.MutabilityOptions(), format: &format)
+    
+    if (format == PropertyListSerialization.PropertyListFormat.xml) {
+      if outputPlist is NSDictionary {
+        os_log("Attempting to write key to: %{public}@", log: CryptMechanism.log, type: .default, String(describing: filepath))
+        _ = (outputPlist as! NSDictionary).write(toFile: filepath, atomically: true)
+      }
+      os_log("Successfully wrote key to: %{public}@", log: CryptMechanism.log, type: .default, String(describing: filepath))
+      return true
+    } else {
+      os_log("rotateRecoveryKey() Error. Format does not equal 'PropertyListSerialization.PropertyListFormat.xml'", log: CryptMechanism.log, type: .error)
+      throw FileVaultError.outputPlistMalformed
+    }
+  }
+  
+  func checkFileExists(path: String) -> Bool {
+    os_log("Checking to see if %{public}@ exists...", log: Check.log, type: .default, String(describing: path))
+    let fm = FileManager.default
+    if fm.fileExists(atPath: path) {
+      os_log("%{public}@ exists...", log: Check.log, type: .default, String(describing: path))
+      return true
+    } else {
+      os_log("%{public}@ doen NOT exists...", log: Check.log, type: .default, String(describing: path))
+      return false
+    }
+  }
 }

--- a/Crypt/Mechanisms/Enablement.swift
+++ b/Crypt/Mechanisms/Enablement.swift
@@ -40,19 +40,21 @@ class Enablement: CryptMechanism {
       guard let password = self.password
         else { allowLogin(); return }
       
+      if getFVEnabled().encrypted && needToRestart() {
+        // This is a catch for if we are on 10.13+ but on HFS.
+        os_log("FileVault is enabled already and `fdesetup status` requests a restart", log: Enablement.log, type: .default)
+        _ = restartMac()
+      }
       let the_settings = NSDictionary.init(dictionary: ["Username" : username, "Password" : password])
-      
+      let filepath = CFPreferencesCopyAppValue(Preferences.outputPath as CFString, bundleid as CFString) as? String ?? "/private/var/root/crypt_output.plist"
       do {
-        let outputPlist = try enableFileVault(the_settings)
-        let filepath = CFPreferencesCopyAppValue(Preferences.outputPath as CFString, bundleid as CFString) as? String ?? "/private/var/root/crypt_output.plist"
-        outputPlist.write(toFile: filepath, atomically: true)
+        _ = try enableFileVault(the_settings, filepath: filepath)
         _ = restartMac()
       }
       catch let error as NSError {
         os_log("Failed to Enable FileVault %{public}@", log: Enablement.log, type: .error, error.localizedDescription)
         _ = allowLogin()
       }
-      
     } else {
       // Allow to login. End of mechanism
       os_log("Hint Value not set Allowing Login...", log: Enablement.log, type: .default)
@@ -71,105 +73,5 @@ class Enablement: CryptMechanism {
     task.arguments = ["-r", "now"]
     task.launch()
     return true
-  }
-  
-  // fdesetup Errors
-  enum FileVaultError: Error {
-    case fdeSetupFailed(retCode: Int32)
-    case outputPlistNull
-    case outputPlistMalformed
-  }
-  
-  // check authrestart capability
-  func checkAuthRestart() -> Bool {
-    let outPipe = Pipe.init()
-    let authRestartCheck = Process.init()
-    authRestartCheck.launchPath = "/usr/bin/fdesetup"
-    authRestartCheck.arguments = ["supportsauthrestart"]
-    authRestartCheck.standardOutput = outPipe
-    authRestartCheck.launch()
-    let outputData = outPipe.fileHandleForReading.availableData
-    let outputString = String(data: outputData, encoding: String.Encoding.utf8) ?? ""
-    if (outputString.range(of: "true") != nil) {
-      os_log("Authrestart capability is 'true', will authrestart as appropriate", log: Enablement.log, type: .default)
-      return true
-    }
-    else {
-      os_log("Authrestart capability is 'false', reverting to standard reboot", log: Enablement.log, type: .default)
-      return false
-    }
-  }
-  
-  // check for Institutional Master keychain
-  func checkInstitutionalRecoveryKey() -> Bool {
-    os_log("Checking for Institutional key...", log: Enablement.log, type: .default)
-    let fileManager = FileManager.default
-    if fileManager.fileExists(atPath: "/Library/Keychains/FileVaultMaster.keychain") {
-      os_log("Institutional key was found...", log: Enablement.log, type: .default)
-      return true
-    } else {
-      os_log("Institutional key NOT found...", log: Enablement.log, type: .default)
-      return false
-    }
-  }
-  
-  // fdesetup wrapper
-  func enableFileVault(_ theSettings : NSDictionary) throws -> NSDictionary {
-    let inputPlist = try PropertyListSerialization.data(fromPropertyList: theSettings,
-      format: PropertyListSerialization.PropertyListFormat.xml, options: 0)
-    
-    let inPipe = Pipe.init()
-    let outPipe = Pipe.init()
-    
-    let task = Process.init()
-    task.launchPath = "/usr/bin/fdesetup"
-    if checkAuthRestart() {
-      os_log("Adding -authrestart to fdesetup arguments...", log: Enablement.log, type: .default)
-      task.arguments = ["enable", "-authrestart", "-outputplist", "-inputplist"]
-    }
-    else {
-      os_log("Using normal arguments for fdesetup...", log: Enablement.log, type: .default)
-      task.arguments = ["enable", "-outputplist", "-inputplist"]
-    }
-    
-    // if there's an IRK, need to add the -keychain argument
-    if checkInstitutionalRecoveryKey() {
-      os_log("Adding -keychain to list of fdesetup arguements since we found an Institutional key...", log: Enablement.log, type: .default)
-      task.arguments?.append("-keychain")
-    }
-    
-    task.standardInput = inPipe
-    task.standardOutput = outPipe
-    task.launch()
-    inPipe.fileHandleForWriting.write(inputPlist)
-    inPipe.fileHandleForWriting.closeFile()
-    task.waitUntilExit()
-    
-    if task.terminationStatus != 0 {
-      let termstatus = String(describing: task.terminationStatus)
-      let termreason = String(describing: task.terminationReason)
-      os_log("fdesetup terminated with a NON-Zero exit status: %{public}@", log: Enablement.log, type: .error, termstatus)
-      os_log("Termreason is: %{public}@", log: Enablement.log, type: .error, termreason)
-      throw FileVaultError.fdeSetupFailed(retCode: task.terminationStatus)
-    }
-    
-    os_log("Trying to get output data", log: Enablement.log, type: .default)
-    let outputData = outPipe.fileHandleForReading.readDataToEndOfFile()
-    outPipe.fileHandleForReading.closeFile()
-    
-    if outputData.count == 0 {
-      os_log("Found nothing in output data", log: Enablement.log, type: .error)
-      throw FileVaultError.outputPlistNull
-    }
-    
-    var format : PropertyListSerialization.PropertyListFormat = PropertyListSerialization.PropertyListFormat.xml
-    let outputPlist = try PropertyListSerialization.propertyList(from: outputData,
-      options: PropertyListSerialization.MutabilityOptions(), format: &format)
-    
-    if (format == PropertyListSerialization.PropertyListFormat.xml) {
-      return outputPlist as! NSDictionary
-    } else {
-      throw FileVaultError.outputPlistMalformed
-    }
   }
 }

--- a/Package/Distribution-Template
+++ b/Package/Distribution-Template
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="1">
+    <title>Crypt replace_version</title>
+    <pkg-ref id="com.grahamgilbert.Crypt"/>
+    <options rootVolumeOnly="true" />
+    <volume-check>
+    	<allowed-os-versions>
+    	    <os-version min="10.12.0" />
+    	</allowed-os-versions>
+    </volume-check>
+    <options customize="never" require-scripts="false"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="com.grahamgilbert.Crypt"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="com.grahamgilbert.Crypt" visible="false">
+        <pkg-ref id="com.grahamgilbert.Crypt"/>
+    </choice>
+    <pkg-ref id="com.grahamgilbert.Crypt" version="replace_version" onConclusion="RequireRestart">Crypt.pkg</pkg-ref>
+</installer-gui-script>

--- a/Package/Makefile
+++ b/Package/Makefile
@@ -5,6 +5,7 @@ GITVERSION=$(shell ./build_no.sh)
 BUNDLE_VERSION=$(shell /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "../Crypt/Info.plist")
 PACKAGE_VERSION=${BUNDLE_VERSION}.${GITVERSION}
 REVERSE_DOMAIN=com.grahamgilbert
+PACKAGE_NAME=${TITLE}
 PAYLOAD=\
 			pack-plugin\
 			pack-script-postinstall\
@@ -30,3 +31,10 @@ pack-checkin: l_Library
 	@sudo ${CP} FoundationPlist.py ${WORK_D}/Library/Crypt/FoundationPlist.py
 	@sudo chown -R root:wheel ${WORK_D}/Library/Crypt
 	@sudo chmod 755 ${WORK_D}/Library/Crypt/checkin
+
+dist: pkg
+	@sudo rm -f Distribution
+	python generate_dist.py
+	@sudo productbuild --distribution Distribution Crypt-${BUNDLE_VERSION}.pkg
+	@sudo rm -f Crypt.pkg
+	@sudo rm -f Distribution

--- a/Package/generate_dist.py
+++ b/Package/generate_dist.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+
+"""
+Sets the right version number and writes the Distribution file from the template
+"""
+
+import plistlib
+import os
+
+def main():
+    """
+    FINAL COUNTDOWN
+    """
+    crypt_plist = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'Crypt','Info.plist')
+    version = plistlib.readPlist(crypt_plist)['CFBundleShortVersionString']
+
+    with open('Distribution-Template', 'r') as the_file:
+        filedata = the_file.read()
+
+    # Replace the target string
+    filedata = filedata.replace('replace_version', version)
+
+    # Write the file out again
+    with open('Distribution', 'w') as the_file:
+        the_file.write(filedata)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION

#### New
* Adds the ability to Enable FileVault on HighSierra APFS without doing a restart or GUI prompt. Still, performs a restart on HFS Drives.
* Did a minor refactor of removing duplicated code and moving any shared functions to the Mechanisms file. 
* Logs now display the StandardError of `/usr/bin/fdesetup` when a failure occurs during enablement or key rotation. 
* Fixes #53 

#### Tests
Tested 10.12.4-6 virtual and physical
Tested 10.13 APFS and 10.13 HFS.