### PR TITLE
fix: Only kill the root loginwindow process

### DIFF
--- a/Package/postinstall
+++ b/Package/postinstall
@@ -167,12 +167,12 @@ def restart_loginwindow():
     pids = find_processes(user='root')
     for pid in pids:
         if 'loginwindow' in pids[pid].get('exe'):
-            cmd = ['/usr/bin/killall', '-HUP', 'loginwindow']
+            cmd = ['/bin/kill', '-9', str(pid)]
             proc = subprocess.Popen(cmd,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
             (stdout, dummy_stderr) = proc.communicate()
-            break
+
 
 def main(argv):
     check_root()


### PR DESCRIPTION
This is so we can support Fast User Switching (FUS) without being
complete jerks and killing sessions all yolo.

Has been tested thoroughly on a physical MacBook Pro 15in Mid 2014.
* On 10.12.6 at loginwindow
* On 10.12.6 at loginwindow w/ FUS session
* On 10.12.6 in GUI session
* On 10.13.2 at loginwindow
* On 10.13.2 at loginwindow w/ FUS session
* On 10.13.2 GUI session

Close #64