### PR TITLE
Default RotateUsedKey to true

### DIFF
--- a/Crypt/Mechanisms/Check.swift
+++ b/Crypt/Mechanisms/Check.swift
@@ -218,7 +218,7 @@ class Check: CryptMechanism {
 
   fileprivate func getRotateUsedKeyPreference() -> Bool {
     guard let rotatekey : Bool = CFPreferencesCopyAppValue("RotateUsedKey" as CFString, bundleid as CFString) as? Bool
-      else { return false }
+      else { return true }
     return rotatekey
   }
 


### PR DESCRIPTION
To match checkin process

Can't take credit. Just doing the work—change originally suggested by @weswhet.