### PR TITLE
Add Xcode version to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The install package will modify the Authorization DB - you need to remove these 
 
 ## Building from source
 
-You will need to configure Xcode to sign the bundle before building. Instructions for this are out of the scope of this readme, and [are available on Apple's site](https://developer.apple.com/support/code-signing/).
+You will need to configure Xcode 9.3 (requires 10.13 or later) to sign the bundle before building. Instructions for this are out of the scope of this readme, and [are available on Apple's site](https://developer.apple.com/support/code-signing/).
 
 * Install [The Luggage](https://github.com/unixorn/luggage)
 * ``cd Package``

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The install package will modify the Authorization DB - you need to remove these 
 
 ## Building from source
 
-You will need to configure Xcode 9.3 (requires 10.13 or later) to sign the bundle before building. Instructions for this are out of the scope of this readme, and [are available on Apple's site](https://developer.apple.com/support/code-signing/).
+You will need to configure Xcode 9.3 (requires 10.13.2 or later) to sign the bundle before building. Instructions for this are out of the scope of this readme, and [are available on Apple's site](https://developer.apple.com/support/code-signing/).
 
 * Install [The Luggage](https://github.com/unixorn/luggage)
 * ``cd Package``


### PR DESCRIPTION
- Opening the project requires Xcode version 9.3, which is only available on macOS 10.13.2 or higher
- Feel free to close without merging if you don't feel like adding this.