### PR TITLE
fix: Remove package working dir prior to build

### DIFF
--- a/Package/Makefile
+++ b/Package/Makefile
@@ -22,6 +22,7 @@ clean-crypt:
 	rm -rf ../build
 
 pack-plugin: build
+	@sudo ${RM} -rf ${WORK_D}
 	@sudo mkdir -p ${WORK_D}/Library/Security/SecurityAgentPlugins
 	@sudo ${CP} -R ../build/Release/Crypt.bundle ${WORK_D}/Library/Security/SecurityAgentPlugins/Crypt.bundle
 


### PR DESCRIPTION
This resolves a very weird issue where the_luggage doesn't cleanup
before building a new version. It can sometimes result in an output
package with twice the file size since the Crypt.bundle is included
twice once at /Lib/Sec/SecAgentPlugins/Crypt.bundle and a second copy
inside the bundle itself.

Since this has happened all of twice, once to Graham in August of
2018 and to me today it isn't a huge issue but an annoying one when it
does happen.

Reference: https://macadmins.slack.com/archives/C07LPS75M/p1544112534025200