### PR TITLE
Update to swift 4.2

### DIFF
--- a/Crypt.xcodeproj/project.pbxproj
+++ b/Crypt.xcodeproj/project.pbxproj
@@ -339,7 +339,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Crypt/Crypt-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Debug;
@@ -368,7 +368,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Crypt/Crypt-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Release;

--- a/Crypt/Info.plist
+++ b/Crypt/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.1</string>
+	<string>3.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3.2.1</string>
+	<string>3.2.2</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2018 The Crypt Project. All rights reserved.</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
A simple update to Swift 4.2 runtime. No code changes were required.

I've tested this using a DEP workflow with 10.13.6, 10.14.1 and 10.14.2.

Since I'm using the NoMAD Login product line I need these two products to use the same swift runtime or the loginwindow will go 💥  