### PR TITLE
skip checking if using the recovery key on 10.15

### DIFF
--- a/Package/checkin
+++ b/Package/checkin
@@ -206,6 +206,13 @@ def using_recovery_key():
     """Check if FileVault is currently unlocked using
     the recovery key.
     """
+    macos_version = get_os_version(only_major_minor=False, as_tuple=False)
+
+    if LooseVersion(macos_version) >= LooseVersion('10.15'):
+        logging.info('Checking if using a recovery key is unstable on 10.15. '
+                     'Skipping.')
+        return False
+
     cmd = ['/usr/bin/fdesetup', 'usingrecoverykey']
     try:
         using_key = subprocess.check_output(cmd).strip()


### PR DESCRIPTION
on Catalina crypt will rotate the key immediately on unlock which invalidates any user password changing causing everyone to be locked out. I also noticed that `/usr/bin/fdesetup', 'usingrecoverykey'` will always return true on 10.15 until the machine is rebooted. In previous versions, this would return false after rotating the key.

Skipping local checking seems to be the best bet.