### PR TITLE
Add note about key rotation in Catalina in above

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ $ sudo defaults write /Library/Preferences/com.grahamgilbert.crypt RemovePlist -
 
 ### RotateUsedKey
 
-Crypt2 can rotate the recovery key, if the key is used to unlock the disk. There is a small caveat that this feature only works if the key is still present on the disk. This is set to `TRUE` by default.
+For macOS 10.14 and below, Crypt2 can rotate the recovery key, if the key is used to unlock the disk. There is a small caveat that this feature only works if the key is still present on the disk. This is set to `TRUE` by default.
 
 ``` bash
 $ sudo defaults write /Library/Preferences/com.grahamgilbert.crypt RotateUsedKey -bool FALSE
 ```
+For macOS 10.15 and above, you may want to use the `ROTATE_VIEWED_SECRETS` key in [Crypt Server](https://github.com/grahamgilbert/Crypt-Server#settings) if you want the client to get instructions to rotate the key.
 
 ### ValidateKey
 


### PR DESCRIPTION
This PR has disabled key rotation for used keys (10.15+): https://github.com/grahamgilbert/crypt/pull/99

So key rotation has to be server-initiated.