### PR TITLE
Prefix octal literal with 0o

### DIFF
--- a/Package/checkin
+++ b/Package/checkin
@@ -448,7 +448,7 @@ def main():
                 os.remove(plist_path)
             else:
                 logging.info("Ensuring permissions on plist.")
-                os.chmod(plist_path, 600)
+                os.chmod(plist_path, 0o600)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change adds the missing "0o" prefix for the octal literal that's used to set the file permission of the plist path.