### PR TITLE
Add escrow error output to logging

### DIFF
--- a/Package/checkin
+++ b/Package/checkin
@@ -192,7 +192,7 @@ def escrow_key(plist):
         server_initiated_rotation(output)
         return True
     else:
-        logging.error("Key escrow unsuccessful. Reason: %s" % error)
+        logging.error("Key escrow unsuccessful. Reason: %s" % error.decode().strip())
         return False
 
 

--- a/Package/checkin
+++ b/Package/checkin
@@ -192,7 +192,7 @@ def escrow_key(plist):
         server_initiated_rotation(output)
         return True
     else:
-        logging.error("Key escrow unsuccessful.")
+        logging.error("Key escrow unsuccessful. Reason: %s" % error)
         return False
 
 


### PR DESCRIPTION
When inspecting logs from Crypt, sometimes admins may see:

`ERROR: Key escrow unsuccessful`

This is a helpful message, but it only explains half of the story. It would be helpful to log the reason why the key escrow was unsuccessful. This PR adds the captured `error` value to the Crypt log(s). The goal of merging this PR would be to provide Crypt administrators broader knowledge about when and why key escrows could fail.