### PR TITLE
fix: Array issue with postRunCommand

### DIFF
--- a/pkg/checkin/escrow.go
+++ b/pkg/checkin/escrow.go
@@ -423,7 +423,11 @@ func serverInitiatedRotation(output string, r utils.Runner, p pref.PrefInterface
 func postRunCommand(r utils.Runner, p pref.PrefInterface) error {
 	command, err := p.GetString("PostRunCommand")
 	if err != nil {
-		return errors.Wrap(err, "failed to get post run command")
+		commandArray, err := p.GetArray("PostRunCommand")
+		if err != nil {
+			return errors.Wrap(err, "failed to get post run command")
+		}
+		command = strings.Join(commandArray, " ")
 	}
 
 	outputPlist, err := p.GetString("OutputPath")

--- a/pkg/checkin/escrow.go
+++ b/pkg/checkin/escrow.go
@@ -421,14 +421,18 @@ func serverInitiatedRotation(output string, r utils.Runner, p pref.PrefInterface
 }
 
 func postRunCommand(r utils.Runner, p pref.PrefInterface) error {
-	command, err := p.GetString("PostRunCommand")
-	if err != nil {
-		commandArray, err := p.GetArray("PostRunCommand")
-		if err != nil {
-			return errors.Wrap(err, "failed to get post run command")
-		}
-		command = strings.Join(commandArray, " ")
-	}
+    var command string
+    var err error
+
+    command, err = p.GetString("PostRunCommand")
+    if err != nil {
+        var commandArray []string
+        commandArray, err = p.GetArray("PostRunCommand")
+        if err != nil {
+            return errors.Wrap(err, "failed to get post run command")
+        }
+        command = strings.Join(commandArray, " ")
+    }
 
 	outputPlist, err := p.GetString("OutputPath")
 	if err != nil {

--- a/pkg/checkin/escrow.go
+++ b/pkg/checkin/escrow.go
@@ -421,18 +421,22 @@ func serverInitiatedRotation(output string, r utils.Runner, p pref.PrefInterface
 }
 
 func postRunCommand(r utils.Runner, p pref.PrefInterface) error {
-    var command string
-    var err error
+	var command string
+	var err error
 
-    command, err = p.GetString("PostRunCommand")
-    if err != nil {
-        var commandArray []string
-        commandArray, err = p.GetArray("PostRunCommand")
-        if err != nil {
-            return errors.Wrap(err, "failed to get post run command")
-        }
-        command = strings.Join(commandArray, " ")
-    }
+	postRunCommand, err := p.Get("PostRunCommand")
+	if err != nil {
+		return errors.Wrap(err, "failed to get post run command")
+	}
+
+	switch v := postRunCommand.(type) {
+	case string:
+		command = v
+	case []string:
+		command = strings.Join(v, " ")
+	default:
+		return errors.New("PostRunCommand is neither a string nor an array of strings")
+	}
 
 	outputPlist, err := p.GetString("OutputPath")
 	if err != nil {

--- a/pkg/checkin/escrow.go
+++ b/pkg/checkin/escrow.go
@@ -420,13 +420,12 @@ func serverInitiatedRotation(output string, r utils.Runner, p pref.PrefInterface
 	return nil
 }
 
-func postRunCommand(r utils.Runner, p pref.PrefInterface) error {
+func getCommand(p pref.PrefInterface) (string, error) {
 	var command string
-	var err error
 
 	postRunCommand, err := p.Get("PostRunCommand")
 	if err != nil {
-		return errors.Wrap(err, "failed to get post run command")
+		return "", errors.Wrap(err, "failed to get post run command")
 	}
 
 	switch v := postRunCommand.(type) {
@@ -435,7 +434,16 @@ func postRunCommand(r utils.Runner, p pref.PrefInterface) error {
 	case []string:
 		command = strings.Join(v, " ")
 	default:
-		return errors.New("PostRunCommand is neither a string nor an array of strings")
+		return "", errors.New("PostRunCommand is neither a string nor an array of strings")
+	}
+
+	return command, nil
+}
+
+func postRunCommand(r utils.Runner, p pref.PrefInterface) error {
+	command, err := getCommand(p)
+	if err != nil {
+		return err
 	}
 
 	outputPlist, err := p.GetString("OutputPath")

--- a/pkg/checkin/escrow_test.go
+++ b/pkg/checkin/escrow_test.go
@@ -66,6 +66,9 @@ func (m *MockPref) SetArray(key string, value []string) error {
 }
 
 func (m *MockPref) Get(key string) (interface{}, error) {
+	if key == "PostRunCommand" {
+		return []string{"test", "command"}, nil
+	}
 	return nil, nil
 }
 
@@ -75,6 +78,14 @@ func (m *MockPref) Set(key string, value interface{}) error {
 
 func (m *MockPref) Delete(key string) error {
 	return nil
+}
+
+func TestGetCommand(t *testing.T) {
+	p := &MockPref{}
+
+	command, err := getCommand(p)
+	assert.NoError(t, err)
+	assert.Equal(t, "test command", command)
 }
 
 func TestBuildCheckinURL(t *testing.T) {


### PR DESCRIPTION
Prefs stored as an array throw an error:
```
% sudo /Library/Crypt/checkin
panic: interface conversion: interface {} is []string, not string
```
This should give the option for either a string or an array.