### PR TITLE
Allow non-trailing slash in escrow URL

### DIFF
--- a/pkg/checkin/escrow.go
+++ b/pkg/checkin/escrow.go
@@ -313,6 +313,10 @@ func buildCheckinURL(p pref.PrefInterface) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get server URL")
 	}
+	if strings.HasSuffix(serverURL, "/default") {
+		serverURL = serverURL + "/checkin"
+		return serverURL, nil
+	}
 	if !strings.HasSuffix(serverURL, "/") {
 		serverURL = serverURL + "/"
 	}

--- a/pkg/checkin/escrow_mock_helper.go
+++ b/pkg/checkin/escrow_mock_helper.go
@@ -1,0 +1,59 @@
+package checkin
+
+type MockPrefV2 struct {
+	ServerURL string
+}
+
+func (m *MockPrefV2) GetString(key string) (string, error) {
+	return m.ServerURL, nil
+}
+
+func (m *MockPrefV2) SetString(key string, value string) error {
+	m.ServerURL = value
+	return nil
+}
+
+func (m *MockPrefV2) GetInt(key string) (int, error) {
+	// not implemented yet. Just to satisty interface
+	return 0, nil
+}
+
+func (m *MockPrefV2) SetInt(key string, value int) error {
+	// not implemented yet. Just to satisty interface
+	return nil
+}
+
+func (m *MockPrefV2) GetArray(key string) ([]string, error) {
+	// not implemented yet. Just to satisty interface
+	return nil, nil
+}
+
+func (m *MockPrefV2) SetArray(key string, value []string) error {
+	// not implemented yet. Just to satisty interface
+	return nil
+}
+
+func (m *MockPrefV2) Get(key string) (interface{}, error) {
+	// not implemented yet. Just to satisty interface
+	return nil, nil
+}
+
+func (m *MockPrefV2) Set(key string, value interface{}) error {
+	// not implemented yet. Just to satisty interface
+	return nil
+}
+
+func (m *MockPrefV2) Delete(key string) error {
+	// not implemented yet. Just to satisty interface
+	return nil
+}
+
+func (m *MockPrefV2) GetBool(key string) (bool, error) {
+	// not implemented yet. Just to satisty interface
+	return false, nil
+}
+
+func (m *MockPrefV2) SetBool(key string, value bool) error {
+	// not implemented yet. Just to satisty interface
+	return nil
+}

--- a/pkg/checkin/escrow_test.go
+++ b/pkg/checkin/escrow_test.go
@@ -39,6 +39,14 @@ func (m *MockPref) GetString(key string) (string, error) {
 	return "", nil
 }
 
+func newMockPref(ServerURL string) *MockPrefV2 {
+	m := &MockPrefV2{}
+
+	m.ServerURL = ServerURL
+
+	return m
+}
+
 func (m *MockPref) SetString(key string, value string) error {
 	return nil
 }
@@ -94,6 +102,24 @@ func TestBuildCheckinURL(t *testing.T) {
 	url, err := buildCheckinURL(p)
 	assert.Nil(t, err)
 	assert.Equal(t, "http://test.com/checkin/", url)
+
+}
+
+func TestBuildNonTrailingSlashURL(t *testing.T) {
+	p := newMockPref("http://test.com/default")
+
+	url, err := buildCheckinURL(p)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://test.com/default/checkin", url)
+
+}
+
+func TestHandleNonDefaultURL(t *testing.T) {
+	p := newMockPref("http://test.com/-default")
+
+	url, err := buildCheckinURL(p)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://test.com/-default/checkin/", url)
 
 }
 


### PR DESCRIPTION
Add if with return for case, tests that cover new behavior, assurance in test that only this path will lead to this behavior

We can definitely discuss how I separated out a new MockPref (I was following a colleagues guidance), it would make sense for the whole test struct to ride alongside the implementation in the other... package? Maybe? Anyway pardon I hacked it in, I can't even get a test build spit out at the moment because no homebrew/I've forgotten how to luggage 😅