### PR TITLE
Remove WatchPaths from launch daemon

### DIFF
--- a/Package/com.grahamgilbert.crypt.plist
+++ b/Package/com.grahamgilbert.crypt.plist
@@ -16,10 +16,6 @@
 	<string>/var/log/crypt.log</string>
 	<key>StandardOutPath</key>
 	<string>/var/log/crypt.log</string>
-	<key>WatchPaths</key>
-	<array>
-		<string>/var/root/crypt_output.plist</string>
-	</array>
 	<key>StartInterval</key>
 	<integer>120</integer>
 </dict>


### PR DESCRIPTION
From `man launchd.plist`:
```
     WatchPaths <array of strings>
     This optional key causes the job to be started if any one of the listed
     paths are modified.

     IMPORTANT: Use of this key is highly discouraged, as filesystem event
     monitoring is highly race-prone, and it is entirely possible for
     modifications to be missed. When modifications are caught, there is no
     guarantee that the file will be in a consistent state when the job is
     launched.
```
This section being removed doesn't seem to impede Crypt's operation (in fact, it may help address https://github.com/grahamgilbert/crypt/issues/128—can't be 100% sure on that, though).