### PR TITLE
Change spaces to a tab in Makefile, remove reference to non-existent path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ pack-checkin: l_Library l_Library_LaunchDaemons build_binary sign_binary
 	@sudo ${CP} build/checkin ${WORK_D}/Library/Crypt/checkin
 	@sudo chown -R root:wheel ${WORK_D}/Library/Crypt
 	@sudo chmod 755 ${WORK_D}/Library/Crypt/checkin
-    @sudo chown -R root:wheel ${WORK_D}/payload
+	@sudo chown -R root:wheel ${WORK_D}/payload
 	@sudo ${INSTALL} -m 644 -g wheel -o root Package/com.grahamgilbert.crypt.plist ${WORK_D}/Library/LaunchDaemons
 
 dist: pkg

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ pack-checkin: l_Library l_Library_LaunchDaemons build_binary sign_binary
 	@sudo ${CP} build/checkin ${WORK_D}/Library/Crypt/checkin
 	@sudo chown -R root:wheel ${WORK_D}/Library/Crypt
 	@sudo chmod 755 ${WORK_D}/Library/Crypt/checkin
-	@sudo chown -R root:wheel ${WORK_D}/payload
+	@sudo chown -R root:wheel ${WORK_D}
 	@sudo ${INSTALL} -m 644 -g wheel -o root Package/com.grahamgilbert.crypt.plist ${WORK_D}/Library/LaunchDaemons
 
 dist: pkg


### PR DESCRIPTION
## Summary
This addresses the issue of `make dist` not including the launch daemon in the resulting package.

### Spaces / Tabs
https://runebook.dev/en/docs/gnu_make/simple-makefile
> In a Makefile, every command line must start with a literal tab character, not spaces.
This PR changes the one set of four spaces to be a single tab.

### Non-existent path
Once the tab is in place, the Makefile was trying to change ownership of a non-existent directory:
`chown: /tmp/the_luggage/Crypt/root/payload: No such file or directory`

So this PR takes out the reference to the non-existent `payload` subdirectory.

## Testing Done
### Before PR
No launch daemon delivered
<img width="625" height="366" alt="Screenshot 2026-05-21 at 09 19 45" src="https://github.com/user-attachments/assets/a69e8fc0-aaee-4204-89d8-9f558b121461" />
### After PR
Launch daemon delivered
<img width="613" height="406" alt="Screenshot 2026-05-21 at 09 27 46" src="https://github.com/user-attachments/assets/d8284c92-d969-433d-b682-352833698d40" />
